### PR TITLE
Migrate to Transformers.js v3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,7 +44,7 @@
     "@tauri-apps/plugin-process": "2.2.1",
     "@tauri-apps/plugin-updater": "2.7.1",
     "@webgpu/types": "^0.1.60",
-    "@xenova/transformers": "^2.17.2",
+    "@huggingface/transformers": "3.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/apps/web/src/models/providers/local/transformerJs.worker.ts
+++ b/apps/web/src/models/providers/local/transformerJs.worker.ts
@@ -6,7 +6,7 @@ import {
   RawImage,
   pipeline,
   env,
-} from "@xenova/transformers";
+} from "@huggingface/transformers";
 import { sizeToString } from "@/utils/format";
 import { ImageProcessor } from "@/utils/imageProcessor";
 
@@ -36,7 +36,8 @@ const createLazyPipeline = <T>(
 const objectDetectionPipeline = createLazyPipeline(
   (onLoading?: (value: LoadingProgressValue) => void) =>
     pipeline("object-detection", "Xenova/detr-resnet-50", {
-      quantized: false,
+      dtype: "fp32",
+      device: 'webgpu',
       progress_callback: onLoading,
     })
 );
@@ -52,6 +53,8 @@ const transformerJsServer = {
     const name = "briaai/RMBG-1.4";
     const model = await AutoModel.from_pretrained(name, {
       config: { model_type: "custom" },
+      device: 'webgpu',
+      dtype: "fp32",
     });
     const processor = await AutoProcessor.from_pretrained(name, {
       config: {


### PR DESCRIPTION
This commit updates the application to use Transformers.js v3.

Key changes:
- Updated package from `@xenova/transformers` to `@huggingface/transformers` version 3.0.0 in `apps/web/package.json`.
- Updated import statements in `apps/web/src/models/providers/local/transformerJs.worker.ts`.
- Modified model loading in `transformerJs.worker.ts` to use `device: 'webgpu'` for GPU acceleration and the `dtype` parameter for quantization.

Testing in the automated environment was hindered by installation timeouts. I recommend you manually test the AI features (background removal, object detection).